### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+script: npm run build
+node_js:
+ - "4"
+ - "6"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "jest --watch --env=jsdom"
+    "prebuild": "npm run test",
+    "test": "jest --no-watchman --env=jsdom",
+    "test:watch": "jest --watch --no-watchman --env=jsdom"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-});


### PR DESCRIPTION
Configured `npm test` to run Jest tests instead of the file watcher.
For development `npm run test:watch` can be used to achieve previous
experience.
This also necessitated a removal of long broken App.test.js.