### PR TITLE
Fix Patternfly imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-preset-latest": "6.14.0",
     "babel-preset-react": "6.11.1",
     "babel-runtime": "6.11.6",
+    "bootstrap": "^3.3.7",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
     "connect-history-api-fallback": "1.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux'
 
-import './index.css';
-import '../node_modules/patternfly/dist/css/patternfly.css'
-import '../node_modules/patternfly/dist/css/patternfly-additions.css'
+import './index.css'
+import 'patternfly/dist/css/patternfly.css'
+import 'patternfly/dist/css/patternfly-additions.css'
 
-window.$ = window.jQuery = require('../node_modules/jquery/dist/jquery');
-var Bootstrap = {};
-Bootstrap.$ = window.$;
-require('../node_modules/bootstrap/dist/js/bootstrap');
-require('../node_modules/patternfly/dist/js/patternfly');
+// Patternfly dependencies
+// jQuery needs to be globally available (webpack.ProvidePlugin can be also used for this)
+window.$ = window.jQuery = require('jquery')
+require('bootstrap/dist/js/bootstrap')
+require('patternfly/dist/js/patternfly')
 
 import store, {sagaMiddleware} from './store'
 import Selectors from './selectors'


### PR DESCRIPTION
index.js imports of patternfly js and css resources depended on non-existing
bootstrap dependency. This was fixed by adding an explicit npm dependency on bootstrap and aligned with the reference import style given by ovirt-ui-components.
