### PR TITLE
Enable ovirt-web-ui for dependency of ovirt-engine

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@
 
 OVIRT_CACHE_DIR	?= $(HOME)/ovirt-cache
 USER_PORTAL_DIR = $(datarootdir)/ovirt-web-ui
-OVIRT_EAR_DIR = $(datarootdir)/ovirt-engine/engine.ear
+OVIRT_ENGINE_DIR = $(datarootdir)/ovirt-engine
 
 SHELL := /bin/bash
 export PATH := /usr/share/ovirt-engine-nodejs/bin:../node_modules/.bin:$(PATH)
@@ -22,7 +22,7 @@ export PATH := /usr/share/ovirt-engine-nodejs/bin:../node_modules/.bin:$(PATH)
 EXTRA_DIST = \
 	autogen.sh \
 	ovirt-web-ui.spec \
-  ovirt-web-ui.spec.in \
+    ovirt-web-ui.spec.in \
 	README.md \
 	LICENSE \
 	src \
@@ -94,7 +94,11 @@ ovirt-web-ui:
 
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(USER_PORTAL_DIR)
-	cp -rpv build/* $(DESTDIR)$(USER_PORTAL_DIR)
+	$(MKDIR_P) $(DESTDIR)$(OVIRT_ENGINE_DIR)
+	cp -rpv build/ovirt-web-ui.war $(DESTDIR)$(USER_PORTAL_DIR)
+	cp -rpv build/etc $(DESTDIR)/$(sysconfdir)
+	echo "ln -s" $(DESTDIR)$(USER_PORTAL_DIR)/ovirt-web-ui.war $(DESTDIR)$(OVIRT_ENGINE_DIR)/ovirt-web-ui.war
+	ln -s ../ovirt-web-ui/ovirt-web-ui.war $(DESTDIR)$(OVIRT_ENGINE_DIR)/ovirt-web-ui.war
 
 distclean-local:
 	rm -rf ${DISTCLEANDIRS}

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ define([VERSION_MAJOR], [0])
 define([VERSION_MINOR], [1])
 define([VERSION_FIX], [0])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
-define([VERSION_RELEASE], [3])
+define([VERSION_RELEASE], [4])
 
 AC_INIT([ovirt-web-ui], VERSION_NUMBER, [mlibra@redhat.com])
 PACKAGE_RPM_VERSION="VERSION_NUMBER"

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -44,31 +44,13 @@ make
 
 %install
 make install DESTDIR=%{buildroot}
-mkdir -p %{buildroot}%{_datarootdir}/ovirt-engine/engine.ear
-ln -s %{_userportaldir}/ovirt-web-ui.war %{buildroot}%{_datarootdir}/ovirt-engine/engine.ear/ovirt-web-ui.war
 
-%post
-cp %{_ovirt_engine_ear_application_xml} %{_ovirt_engine_ear_application_xml}.preOvirtWebUi
-cat %{_ovirt_engine_ear_application_xml} | sed -e 's/\(<\/application>\)/ <module><web><web-uri>ovirt-web-ui.war<\/web-uri><context-root>\/ovirt-engine\/web-ui<\/context-root><\/web><\/module> \n\1/' > %{_ovirt_engine_ear_application_xml}.updated
-mv %{_ovirt_engine_ear_application_xml}.updated %{_ovirt_engine_ear_application_xml}
-
-cp %{_ovirt_engine_conf} %{_ovirt_engine_conf}.preOvirtWebUi
-echo 'ENGINE_SSO_AUTH_SEQUENCE_webui=~' >> %{_ovirt_engine_conf}
-
-%postun
-cp %{_ovirt_engine_ear_application_xml} %{_ovirt_engine_ear_application_xml}.preOvirtWebUiUninstall
-cat %{_ovirt_engine_ear_application_xml} | sed -e 's/<module>.*ovirt-web-ui.war.*<\/module>/ /' > %{_ovirt_engine_ear_application_xml}.updated
-mv %{_ovirt_engine_ear_application_xml}.updated %{_ovirt_engine_ear_application_xml}
-
-cp %{_ovirt_engine_conf} %{_ovirt_engine_conf}.preOvirtWebUiUninstall
-cat %{_ovirt_engine_conf} | sed -e 's/ENGINE_SSO_AUTH_SEQUENCE_webui=~//' > %{_ovirt_engine_conf}.updated
-mv %{_ovirt_engine_conf}.updated %{_ovirt_engine_conf}
-
-%files 
+%files
 %doc README.md 
 %license LICENSE
 %{_userportaldir}
-%{_datarootdir}/ovirt-engine/engine.ear/ovirt-web-ui.war
+%{_datarootdir}/ovirt-engine/ovirt-web-ui.war
+%{_sysconfdir}/ovirt-engine/engine.conf.d/50-ovirt-web-ui.conf
 
 %changelog
 * Mon Nov 14 2016 Marek Libra <mlibra@redhat.com> - 0.1.0

--- a/packaging/etc/ovirt-engine/engine.conf.d/50-ovirt-web-ui.conf
+++ b/packaging/etc/ovirt-engine/engine.conf.d/50-ovirt-web-ui.conf
@@ -1,0 +1,3 @@
+ENGINE_APPS="${ENGINE_APPS} ovirt-web-ui.war"
+# ovirt-web-ui auth sequence
+ENGINE_SSO_AUTH_SEQUENCE_webui=~

--- a/packaging/ovirt-web-ui.war/WEB-INF/jboss-web.xml
+++ b/packaging/ovirt-web-ui.war/WEB-INF/jboss-web.xml
@@ -22,6 +22,7 @@ limitations under the License.
   xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_8_0.xsd"
   version="8.0">
 
+  <context-root>/ovirt-engine/web-ui</context-root>
   <symbolic-linking-enabled>true</symbolic-linking-enabled>
 
 </jboss-web>


### PR DESCRIPTION
The ovirt-web-ui is becomming a hard-dependency of ovirt-engine.

ovirt-engine.conf is dynamically updated
move ovirt-web-ui.war out from ovirt-engine.ear to same level as restapi.war or ovirt-engine.ear